### PR TITLE
Dev

### DIFF
--- a/include/alias/vec2_bool.hpp
+++ b/include/alias/vec2_bool.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef ALIAS_VEC2_BOOL_H
+#define ALIAS_VEC2_BOOL_H
+
+#include "../detail/type_vec2.hpp"
+
+namespace smath {
+
+	// Boolean vector with 2 components
+	using vec2b = vec<2, bool>;
+
+} // namespace smath
+
+#endif

--- a/include/alias/vec2_double.hpp
+++ b/include/alias/vec2_double.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef ALIAS_VEC2_DOUBLE_H
+#define ALIAS_VEC2_DOUBLE_H
+
+#include "../detail/type_vec2.hpp"
+
+namespace smath {
+
+	// Double-precision floating-point vector with 2 components
+	using vec2d = vec<2, double>;
+
+} // namespace smath
+
+#endif

--- a/include/alias/vec2_float.hpp
+++ b/include/alias/vec2_float.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef ALIAS_VEC2_FLOAT_H
+#define ALIAS_VEC2_FLOAT_H
+
+#include "../detail/type_vec2.hpp"
+
+namespace smath {
+
+	// Single-precision floating-point vector with 2 components
+	using vec2 = vec<2, float>;
+
+} // namespace smath
+
+#endif

--- a/include/alias/vec2_integer.hpp
+++ b/include/alias/vec2_integer.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifndef ALIAS_VEC2_INTEGER_H
+#define ALIAS_VEC2_INTEGER_H
+
+#include "../detail/type_vec2.hpp"
+
+namespace smath {
+
+	// Integer vector with 2 components
+	using vec2i = vec<2, int>;
+
+} // namespace smath
+
+#endif

--- a/include/detail/qualifier.hpp
+++ b/include/detail/qualifier.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifndef DETAIL_QUALIFIER_H
+#define DETAIL_QUALIFIER_H
+
+#include <cassert>
+
+namespace smath {
+
+	// ---------------
+	// --- vectors ---
+	// ---------------
+	// Supports:
+	// - 2 components (x, y)
+	// - 3 components (x, y, z)
+	// - 4 components (x, y, z, w)
+
+	/**
+	 * General vector of arbitrary length and type.
+	 * @tparam L The length of the vector, in range [2, 4]
+	 * @tparam T The type of data to store in the vector (float, double or integer)
+	 */
+	template<int L, class T> struct vec;
+
+} // namespace smath
+
+#endif

--- a/include/detail/type_vec2.hpp
+++ b/include/detail/type_vec2.hpp
@@ -179,6 +179,63 @@ namespace smath {
 	template<class T>
 	constexpr vec<2, T> operator/(const vec<2, T> &v1, const vec<2, T> &v2);
 
+	template<class T>
+	constexpr vec<2, T> operator%(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator%(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator%(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	// -- Bitwise arithmetic operators --
+
+	template<class T>
+	constexpr vec<2, T> operator&(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator&(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator&(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator|(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator|(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator|(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator^(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator^(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator^(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator<<(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator<<(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator<<(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator>>(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator>>(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator>>(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator~(const vec<2, T> &v);
+
+	// -- Boolean operators --
+
+	template<class T>
+	constexpr bool operator==(const vec<2, T> &v1, const vec<2, T> &v2);
+	template<class T>
+	constexpr bool operator!=(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	constexpr vec<2, bool> operator&&(const vec<2, bool> &v1, const vec<2, bool> &v2);
+	constexpr vec<2, bool> operator||(const vec<2, bool> &v1, const vec<2, bool> &v2);
+
 } // namespace smath
 
 #include "type_vec2.inl"

--- a/include/detail/type_vec2.hpp
+++ b/include/detail/type_vec2.hpp
@@ -15,86 +15,6 @@ namespace smath {
 		T x;
 		T y;
 
-		// -- Constructors --
-
-		/**
-		 * Default constructor for a 2-component vector.
-		 */
-		constexpr vec()
-			: x{}, y{}
-		{}
-
-		/**
-		 * Constructor to initialize a vector to a single scalar.
-		 * @tparam T The type of the vector.
-		 * @param scalar The scalar value to initialize the vector to.
-		 */
-		constexpr vec(T scalar)
-			: x(scalar), y(scalar)
-		{}
-
-		/**
-		 * Constructor to initialize each component in the vector.
-		 * @tparam T The type of the vector.
-		 * @param _x The x component of the vector.
-		 * @param _y The y component of the vector.
-		 */
-		constexpr vec(T _x, T _y)
-			: x(_x), y(_y)
-		{}
-
-		/**
-		 * Constructor to initialize each component in the vector using
-		 * different types
-		 */
-		template<class A, class B>
-		constexpr vec(A _x, B _y)
-			: x(static_cast<T>(_x))
-			, y(static_cast<T>(_y))
-		{}
-
-		/**
-		 * Constructor to initialize a vector to another vector.
-		 * @param v The vector initialize to.
-		 */
-		constexpr vec(const vec<2, T> &v)
-			: x(v.x), y(v.y)
-		{}
-
-		/**
-		 * Constructor to initialize a vector to a vector from another type.
-		 * @param v The vector of a different type.
-		 */
-		template<class A>
-		constexpr vec(const vec<2, A> &v)
-			: x(static_cast<T>(v.x))
-			, y(static_cast<T>(v.y))
-		{}
-
-		// -- Element Accesses --
-
-		constexpr T& operator[](int i) {
-			assert(i >= 0 && i < this->length());
-			switch(i) {
-				default:
-				case 0:
-					return x;
-				case 1:
-					return y;
-			}
-		}
-
-		constexpr const T& operator[](int i) const {
-			assert(i >= 0 && i < this->length());
-			switch(i) {
-				default:
-				case 0:
-					return x;
-				case 1:
-					return y;
-			}
-		}
-
 		/**
 		 * @returns The number of components that the vector contains.
 		 */
@@ -102,81 +22,165 @@ namespace smath {
 			return 2;
 		}
 
+		// -- Constructors --
+
+		/**
+		 * Default constructor for a 2-component vector.
+		 */
+		constexpr vec();
+
+		/**
+		 * Constructor to initialize a vector to a single scalar.
+		 * @tparam T The type of the vector.
+		 * @param scalar The scalar value to initialize the vector to.
+		 */
+		constexpr vec(T scalar);
+
+		/**
+		 * Constructor to initialize each component in the vector.
+		 * @tparam T The type of the vector.
+		 * @param _x The x component of the vector.
+		 * @param _y The y component of the vector.
+		 */
+		constexpr vec(T _x, T _y);
+
+		/**
+		 * Constructor to initialize each component in the vector using
+		 * different parameter types.
+		 * @tparam A Some data type that is not the same base data type.
+		 * @tparam B Some data type that is not the same base data type.
+		 * @param _x The x component of the vector.
+		 * @param _y The y component of the vector.
+		 */
+		template<class A, class B>
+		constexpr vec(A _x, B _y);
+
+		/**
+		 * Constructor to initialize a vector to another vector.
+		 * @param v The vector initialize to.
+		 */
+		constexpr vec(const vec<2, T> &v);
+
+		/**
+		 * Constructor to initialize a vector to a vector from another type.
+		 * @tparam A Some data type that is not the same as the base data type.
+		 * @param v The vector of a different type.
+		 */
+		template<class A>
+		constexpr vec(const vec<2, A> &v);
+
+		// -- Element accesses --
+
+		constexpr T& operator[](int i);
+		constexpr const T& operator[](int i) const;
+
 		// -- Unary arithmetic operators --
 
-		constexpr vec<2, T> operator+(const vec<2, T> &v) {
-			return v;
-		}
-
-		constexpr vec<2, T> operator-(const vec<2, T> &v) {
-			return vec<2, T>(-v.x, -v.y);
-		}
+		template<class A>
+		constexpr vec<2, T>& operator=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator=(const vec<2, A> &v) {
-			this->x = static_cast<T>(v.x);
-			this->y = static_cast<T>(v.y);
-			return *this;
-		}
+		constexpr vec<2, T>& operator+=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator+=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator+=(A scalar) {
-			this->x += static_cast<T>(scalar);
-			this->y += static_cast<T>(scalar);
-			return *this;
-		}
+		constexpr vec<2, T>& operator-=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator-=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator+=(const vec<2, A> &v) {
-			this->x += static_cast<T>(v.x);
-			this->y += static_cast<T>(v.y);
-			return *this;
-		}
+		constexpr vec<2, T>& operator*=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator*=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator-=(A scalar) {
-			this->x -= static_cast<T>(scalar);
-			this->y -= static_cast<T>(scalar);
-			return *this;
-		}
+		constexpr vec<2, T>& operator/=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator/=(const vec<2, A> &v);
+
+		// -- Unary bit operators --
 
 		template<class A>
-		constexpr vec<2, T>& operator-=(const vec<2, A> &v) {
-			this->x -= static_cast<T>(v.x);
-			this->y -= static_cast<T>(v.y);
-			return *this;
-		}
+		constexpr vec<2, T>& operator%=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator%=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator*=(A scalar) {
-			this->x *= static_cast<T>(scalar);
-			this->y *= static_cast<T>(scalar);
-			return *this;
-		}
+		constexpr vec<2, T>& operator&=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator&=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator*=(const vec<2, A> &v) {
-			this->x *= static_cast<T>(v.x);
-			this->y *= static_cast<T>(v.y);
-			return *this;
-		}
+		constexpr vec<2, T>& operator|=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator|=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator/=(A scalar) {
-			this->x /= static_cast<T>(scalar);
-			this->y /= static_cast<T>(scalar);
-			return *this;
-		}
+		constexpr vec<2, T>& operator^=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator^=(const vec<2, A> &v);
 
 		template<class A>
-		constexpr vec<2, T>& operator/=(const vec<2, A> &v) {
-			this->x /= static_cast<T>(v.x);
-			this->y /= static_cast<T>(v.y);
-			return *this;
-		}
+		constexpr vec<2, T>& operator<<=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator<<=(const vec<2, A> &v);
+
+		template<class A>
+		constexpr vec<2, T>& operator>>=(A scalar);
+		template<class A>
+		constexpr vec<2, T>& operator>>=(const vec<2, A> &v);
+
+		// -- Increment and decrement operators --
+
+		constexpr vec<2, T>& operator++();
+		constexpr vec<2, T> operator++(int);
+
+		constexpr vec<2, T>& operator--();
+		constexpr vec<2, T> operator--(int);
 
 	};
 
+	// -- Unary arithmetic operators --
+
+	template<class T>
+	constexpr vec<2, T> operator+(const vec<2, T> &v);
+
+	template<class T>
+	constexpr vec<2, T> operator-(const vec<2, T> &v);
+
+	// -- Binary arithmetic operators --
+
+	template<class T>
+	constexpr vec<2, T> operator+(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator+(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator+(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator-(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator-(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator-(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator*(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator*(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator*(const vec<2, T> &v1, const vec<2, T> &v2);
+
+	template<class T>
+	constexpr vec<2, T> operator/(const vec<2, T> &v, T scalar);
+	template<class T>
+	constexpr vec<2, T> operator/(T scalar, const vec<2, T> &v);
+	template<class T>
+	constexpr vec<2, T> operator/(const vec<2, T> &v1, const vec<2, T> &v2);
+
 } // namespace smath
+
+#include "type_vec2.inl"
 
 #endif

--- a/include/detail/type_vec2.hpp
+++ b/include/detail/type_vec2.hpp
@@ -1,0 +1,182 @@
+#pragma once
+
+#ifndef DETAIL_TYPE_VEC2_H
+#define DETAIL_TYPE_VEC2_H
+
+#include "qualifier.hpp"
+
+namespace smath {
+
+	template<class T>
+	struct vec<2, T> {
+
+		// -- Components --
+
+		T x;
+		T y;
+
+		// -- Constructors --
+
+		/**
+		 * Default constructor for a 2-component vector.
+		 */
+		constexpr vec()
+			: x{}, y{}
+		{}
+
+		/**
+		 * Constructor to initialize a vector to a single scalar.
+		 * @tparam T The type of the vector.
+		 * @param scalar The scalar value to initialize the vector to.
+		 */
+		constexpr vec(T scalar)
+			: x(scalar), y(scalar)
+		{}
+
+		/**
+		 * Constructor to initialize each component in the vector.
+		 * @tparam T The type of the vector.
+		 * @param _x The x component of the vector.
+		 * @param _y The y component of the vector.
+		 */
+		constexpr vec(T _x, T _y)
+			: x(_x), y(_y)
+		{}
+
+		/**
+		 * Constructor to initialize each component in the vector using
+		 * different types
+		 */
+		template<class A, class B>
+		constexpr vec(A _x, B _y)
+			: x(static_cast<T>(_x))
+			, y(static_cast<T>(_y))
+		{}
+
+		/**
+		 * Constructor to initialize a vector to another vector.
+		 * @param v The vector initialize to.
+		 */
+		constexpr vec(const vec<2, T> &v)
+			: x(v.x), y(v.y)
+		{}
+
+		/**
+		 * Constructor to initialize a vector to a vector from another type.
+		 * @param v The vector of a different type.
+		 */
+		template<class A>
+		constexpr vec(const vec<2, A> &v)
+			: x(static_cast<T>(v.x))
+			, y(static_cast<T>(v.y))
+		{}
+
+		// -- Element Accesses --
+
+		constexpr T& operator[](int i) {
+			assert(i >= 0 && i < this->length());
+			switch(i) {
+				default:
+				case 0:
+					return x;
+				case 1:
+					return y;
+			}
+		}
+
+		constexpr const T& operator[](int i) const {
+			assert(i >= 0 && i < this->length());
+			switch(i) {
+				default:
+				case 0:
+					return x;
+				case 1:
+					return y;
+			}
+		}
+
+		/**
+		 * @returns The number of components that the vector contains.
+		 */
+		static constexpr int length() {
+			return 2;
+		}
+
+		// -- Unary arithmetic operators --
+
+		constexpr vec<2, T> operator+(const vec<2, T> &v) {
+			return v;
+		}
+
+		constexpr vec<2, T> operator-(const vec<2, T> &v) {
+			return vec<2, T>(-v.x, -v.y);
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator=(const vec<2, A> &v) {
+			this->x = static_cast<T>(v.x);
+			this->y = static_cast<T>(v.y);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator+=(A scalar) {
+			this->x += static_cast<T>(scalar);
+			this->y += static_cast<T>(scalar);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator+=(const vec<2, A> &v) {
+			this->x += static_cast<T>(v.x);
+			this->y += static_cast<T>(v.y);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator-=(A scalar) {
+			this->x -= static_cast<T>(scalar);
+			this->y -= static_cast<T>(scalar);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator-=(const vec<2, A> &v) {
+			this->x -= static_cast<T>(v.x);
+			this->y -= static_cast<T>(v.y);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator*=(A scalar) {
+			this->x *= static_cast<T>(scalar);
+			this->y *= static_cast<T>(scalar);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator*=(const vec<2, A> &v) {
+			this->x *= static_cast<T>(v.x);
+			this->y *= static_cast<T>(v.y);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator/=(A scalar) {
+			this->x /= static_cast<T>(scalar);
+			this->y /= static_cast<T>(scalar);
+			return *this;
+		}
+
+		template<class A>
+		constexpr vec<2, T>& operator/=(const vec<2, A> &v) {
+			this->x /= static_cast<T>(v.x);
+			this->y /= static_cast<T>(v.y);
+			return *this;
+		}
+
+	};
+
+} // namespace smath
+
+#endif

--- a/include/detail/type_vec2.inl
+++ b/include/detail/type_vec2.inl
@@ -380,4 +380,182 @@ namespace smath {
 		);
 	}
 
+	template<class T>
+	constexpr vec<2, T> operator%(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x % scalar,
+			v.y % scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator%(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar % v.x,
+			scalar % v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator%(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x % v2.x,
+			v1.y % v2.y
+		);
+	}
+
+	// -- Bitwise arithmetic operators --
+
+	template<class T>
+	constexpr vec<2, T> operator&(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x & scalar,
+			v.y & scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator&(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar & v.x,
+			scalar & v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator&(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x & v2.x,
+			v1.y & v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator|(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x | scalar,
+			v.y | scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator|(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar | v.x,
+			scalar | v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator|(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x | v2.x,
+			v1.y | v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator^(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x ^ scalar,
+			v.y ^ scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator^(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar ^ v.x,
+			scalar ^ v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator^(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x ^ v2.x,
+			v1.y ^ v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator<<(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x << scalar,
+			v.y << scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator<<(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar << v.x,
+			scalar << v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator<<(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x << v2.x,
+			v1.y << v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator>>(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x >> scalar,
+			v.y >> scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator>>(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar >> v.x,
+			scalar >> v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator>>(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x >> v2.x,
+			v1.y >> v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator~(const vec<2, T> &v) {
+		return vec<2, T>(
+			~v.x,
+			~v.y
+		);
+	}
+
+	template<class T>
+	constexpr bool operator==(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return v1.x == v2.x && v1.y == v2.y;
+	}
+
+	template<class T>
+	constexpr bool operator!=(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return !(v1 == v2);
+	}
+
+	constexpr vec<2, bool> operator&&(const vec<2, bool> &v1, const vec<2, bool> &v2) {
+		return vec<2, bool>(
+			v1.x && v2.x,
+			v1.y && v2.y
+		);
+	}
+
+	constexpr vec<2, bool> operator||(const vec<2, bool> &v1, const vec<2, bool> &v2) {
+		return vec<2, bool>(
+			v1.x || v2.x,
+			v1.y || v2.y
+		);
+	}
+
 } // namespace smath

--- a/include/detail/type_vec2.inl
+++ b/include/detail/type_vec2.inl
@@ -1,0 +1,383 @@
+/**
+ * Implementation of the type_vec2.hpp header functions.
+ */
+
+namespace smath {
+
+	// -- Constructors --
+
+	template<class T>
+	constexpr vec<2, T>::vec()
+		: x{}, y{}
+	{}
+
+	template<class T>
+	constexpr vec<2, T>::vec(T scalar)
+		: x(scalar), y(scalar)
+	{}
+
+	template<class T>
+	constexpr vec<2, T>::vec(T _x, T _y)
+		: x(_x), y(_y)
+	{}
+
+	template<class T>
+	template<class A, class B>
+	constexpr vec<2, T>::vec(A _x, B _y)
+		: x(static_cast<T>(_x))
+		, y(static_cast<T>(_y))
+	{}
+
+	template<class T>
+	constexpr vec<2, T>::vec(const vec<2, T> &v)
+		: x(v.x), y(v.y)
+	{}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>::vec(const vec<2, A> &v)
+		: x(static_cast<T>(v.x))
+		, y(static_cast<T>(v.y))
+	{}
+
+	// -- Element Accesses --
+
+	template<class T>
+	constexpr T& vec<2, T>::operator[](int i) {
+		assert(i >= 0 && i < this->length());
+		switch(i) {
+			default:
+			case 0:
+				return x;
+			case 1:
+				return y;
+		}
+	}
+
+	template<class T>
+	constexpr const T& vec<2, T>::operator[](int i) const {
+		assert(i >= 0 && i < this->length());
+		switch(i) {
+			default:
+			case 0:
+				return x;
+			case 1:
+				return y;
+		}
+	}
+
+	// -- Unary arithmetic operators --
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator=(const vec<2, A> &v) {
+		this->x = static_cast<T>(v.x);
+		this->y = static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator+=(A scalar) {
+		this->x += static_cast<T>(scalar);
+		this->y += static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator+=(const vec<2, A> &v) {
+		this->x += static_cast<T>(v.x);
+		this->y += static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator-=(A scalar) {
+		this->x -= static_cast<T>(scalar);
+		this->y -= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator-=(const vec<2, A> &v) {
+		this->x -= static_cast<T>(v.x);
+		this->y -= static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator*=(A scalar) {
+		this->x *= static_cast<T>(scalar);
+		this->y *= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator*=(const vec<2, A> &v) {
+		this->x *= static_cast<T>(v.x);
+		this->y *= static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator/=(A scalar) {
+		this->x /= static_cast<T>(scalar);
+		this->y /= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator/=(const vec<2, A> &v) {
+		this->x /= static_cast<T>(v.x);
+		this->y /= static_cast<T>(v.y);
+		return *this;
+	}
+
+	// -- Unary bit operators --
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator%=(A scalar) {
+		this->x %= static_cast<T>(scalar);
+		this->y %= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator%=(const vec<2, A> &v) {
+		this->x %= static_cast<T>(v.x);
+		this->y %= static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator&=(A scalar) {
+		this->x &= static_cast<T>(scalar);
+		this->y &= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator&=(const vec<2, A> &v) {
+		this->x &= static_cast<T>(v.x);
+		this->y &= static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator|=(A scalar) {
+		this->x |= static_cast<T>(scalar);
+		this->y |= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator|=(const vec<2, A> &v) {
+		this->x |= static_cast<T>(v.x);
+		this->y |= static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator^=(A scalar) {
+		this->x ^= static_cast<T>(scalar);
+		this->y ^= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator^=(const vec<2, A> &v) {
+		this->x ^= static_cast<T>(v.x);
+		this->y ^= static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator<<=(A scalar) {
+		this->x <<= static_cast<T>(scalar);
+		this->y <<= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator<<=(const vec<2, A> &v) {
+		this->x <<= static_cast<T>(v.x);
+		this->y <<= static_cast<T>(v.y);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator>>=(A scalar) {
+		this->x >>= static_cast<T>(scalar);
+		this->y >>= static_cast<T>(scalar);
+		return *this;
+	}
+
+	template<class T>
+	template<class A>
+	constexpr vec<2, T>& vec<2, T>::operator>>=(const vec<2, A> &v) {
+		this->x >>= static_cast<T>(v.x);
+		this->y >>= static_cast<T>(v.y);
+		return *this;
+	}
+
+	// -- Increment and decrement operators --
+
+	template<class T>
+	constexpr vec<2, T>& vec<2, T>::operator++() {
+		// allow for prefix (i.e. ++a)
+		++this->x;
+		++this->y;
+		return *this;
+	}
+
+	template<class T>
+	constexpr vec<2, T> vec<2, T>::operator++(int) {
+		// allow for postfix (i.e. a++)
+		vec<2, T> copy(*this);
+		++*this;
+		return copy;
+	}
+
+	template<class T>
+	constexpr vec<2, T>& vec<2, T>::operator--() {
+		--this->x;
+		--this->y;
+		return *this;
+	}
+
+	template<class T>
+	constexpr vec<2, T> vec<2, T>::operator--(int) {
+		vec<2, T> copy(*this);
+		--*this;
+		return copy;
+	}
+
+	// -- Unary arithmetic operators --
+
+	template<class T>
+	constexpr vec<2, T> operator+(const vec<2, T> &v) {
+		return v;
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator-(const vec<2, T> &v) {
+		return vec<2, T>(-v.x, -v.y);
+	}
+
+	// -- Binary arithmetic operators --
+
+	template<class T>
+	constexpr vec<2, T> operator+(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x + scalar,
+			v.y + scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator+(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar + v.x,
+			scalar + v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator+(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x + v2.x,
+			v1.y + v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator-(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x - scalar,
+			v.y - scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator-(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar - v.x,
+			scalar - v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator-(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x - v2.x,
+			v1.y - v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator*(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x * scalar,
+			v.y * scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator*(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar * v.x,
+			scalar * v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator*(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x * v2.x,
+			v1.y * v2.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator/(const vec<2, T> &v, T scalar) {
+		return vec<2, T>(
+			v.x / scalar,
+			v.y / scalar
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator/(T scalar, const vec<2, T> &v) {
+		return vec<2, T>(
+			scalar / v.x,
+			scalar / v.y
+		);
+	}
+
+	template<class T>
+	constexpr vec<2, T> operator/(const vec<2, T> &v1, const vec<2, T> &v2) {
+		return vec<2, T>(
+			v1.x / v2.x,
+			v1.y / v2.y
+		);
+	}
+
+} // namespace smath

--- a/include/smath.hpp
+++ b/include/smath.hpp
@@ -8,5 +8,6 @@
 #include "math.hpp"
 #include "template_types.hpp"
 #include "trigonometry.hpp"
+#include "vec2.hpp"
 
 #endif

--- a/include/vec2.hpp
+++ b/include/vec2.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifndef VEC2_H
+#define VEC2_H
+
+#include "alias/vec2_bool.hpp"
+#include "alias/vec2_double.hpp"
+#include "alias/vec2_float.hpp"
+#include "alias/vec2_integer.hpp"
+
+#endif

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -183,19 +183,24 @@ void test_scale() {
  * Test my implementation of vectors.
  */
 void test_vec2() {
-	std::cout << "-------- VECTOR 2 --------\n";
-	smath::vec2 zero{};
+	std::cout << "-------- VECTOR 2f --------\n";
 	smath::vec2 A{ 4.2f, 0.05f };
 	smath::vec2 B{ 8.9f, 1.1f };
 
-	smath::vec2 addAB{ B };
-	addAB += A;
+	smath::vec2 C{ B };
+	C += A;
 
 	std::cout << A.length() << '\n';
 	std::cout << A[0] << '\n';
 
 	std::cout << B[0] << '\n';
-	std::cout << "(" << addAB[0] << ", " << addAB[1] << ")\n";
+	std::cout << '(' << C[0] << ", " << C[1] << ")\n";
+
+	smath::vec2 D{ B * C };
+	std::cout << '(' << D.x << ", " << D.y << ")\n";
+
+	smath::vec2 E{ 1.0f / B };
+	std::cout << '(' << E.x << ", " << E.y << ")\n";
 	std::cout << '\n';
 }
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -86,7 +86,7 @@ void test_sqrt() {
 	std::cout << std::sqrt(16.0f) << '\n';
 	std::cout << smath::sqrt(16.0) << '\n';
 	std::cout << std::sqrt(16.0) << '\n';
-	std::cout << '\n';
+	std::cout << std::setprecision(4) << '\n';
 }
 
 /**
@@ -180,6 +180,26 @@ void test_scale() {
 }
 
 /**
+ * Test my implementation of vectors.
+ */
+void test_vec2() {
+	std::cout << "-------- VECTOR 2 --------\n";
+	smath::vec2 zero{};
+	smath::vec2 A{ 4.2f, 0.05f };
+	smath::vec2 B{ 8.9f, 1.1f };
+
+	smath::vec2 addAB{ B };
+	addAB += A;
+
+	std::cout << A.length() << '\n';
+	std::cout << A[0] << '\n';
+
+	std::cout << B[0] << '\n';
+	std::cout << "(" << addAB[0] << ", " << addAB[1] << ")\n";
+	std::cout << '\n';
+}
+
+/**
  * Test the differences between the constants
  */
 void test_consts() {
@@ -206,6 +226,7 @@ int main() {
 	test_ceil();
 	test_convert_radians_degrees();
 	test_scale();
+	test_vec2();
 	test_consts();
 
 	return 0;


### PR DESCRIPTION
# Add
- 2-component vector aliases 
  - `vec2` for vector of type `float`
  - `vec2d` for vector of type `double`
  - `vec2i` for vector of type `int`
  - `vec2b` for vector of type `bool`
- Complete implementation for `vec2` of type `float`
- Tests for `vec2`