### PR TITLE
Struct to class

### DIFF
--- a/smath/detail/function.hpp
+++ b/smath/detail/function.hpp
@@ -10,9 +10,10 @@ namespace smath {
 	namespace function {
 
 		/**
-		 * @brief Template class to execute a function with a single (one) parameter.
+		 * @brief Template class to execute a function with a single parameter.
 		 * @tparam L The number of components of the vector.
-		 * @tparam T The type of the vector (bool, int, double, float)
+		 * @tparam T The type of the given vector (bool, int, double, float)
+		 * @tparam A The return type of the vector (bool, int, double, float)
 		 */
 		template<template<length_t L, class T> class vec, length_t L, class A, class T>
 		struct one{};
@@ -38,10 +39,18 @@ namespace smath {
 			}
 		};
 
+		template<template<length_t L, class T> class vec, class A, class T>
+		struct one<vec, 4, A, T> {
+			SMATH_CONSTEXPR static vec<4, A> apply(A (*func) (T x), const vec<4, T> &v) {
+				return vec<4, A>(func(v.x), func(v.y), func(v.z), func(v.w));
+			}
+		};
+
 		/**
 		 * @brief Template class to execute a function with two parameters.
 		 * @tparam L The number of components of the vector.
-		 * @tparam T The type of the vector (bool, int, double, float)
+		 * @tparam T The type of the given vector (bool, int, double, float)
+		 * @tparam A The return type of the vector (bool, int, double, float)
 		 */
 		template<template<length_t L, class T> class vec, length_t L, class T>
 		struct two{};
@@ -64,6 +73,13 @@ namespace smath {
 		struct two<vec, 3, T> {
 			SMATH_CONSTEXPR static vec<3, T> apply(T (*func) (T x, T y), const vec<3, T> &a, const vec<3, T> &b) {
 				return vec<3, T>(func(a.x, b.x), func(a.y, b.y), func(a.z, b.z));
+			}
+		};
+
+		template<template<length_t L, class T> class vec, class T>
+		struct two<vec, 4, T> {
+			SMATH_CONSTEXPR static vec<4, T> apply(T (*func) (T x, T y), const vec<4, T> &a, const vec<4, T> &b) {
+				return vec<4, T>(func(a.x, b.x), func(a.y, b.y), func(a.z, b.z), func(a.w, b.w));
 			}
 		};
 

--- a/smath/types/qualifier.hpp
+++ b/smath/types/qualifier.hpp
@@ -20,11 +20,11 @@ namespace smath {
 	// - 4 components (x, y, z, w)
 
 	/**
-	 * General vector of arbitrary length and type.
+	 * General vector class of arbitrary length and type.
 	 * @tparam L The length of the vector, in range [1, 4]
 	 * @tparam T The type of data to store in the vector (bool, int, float or double)
 	 */
-	template<length_t L, class T> struct vec;
+	template<length_t L, class T> class vec;
 
 } // namespace smath
 

--- a/smath/types/type_vec1.hpp
+++ b/smath/types/type_vec1.hpp
@@ -8,7 +8,13 @@
 namespace smath {
 
 	template<class T>
-	struct vec<1, T> {
+	class vec<1, T> {
+
+	private:
+
+		static SMATH_CONSTEXPR length_t m_size{ 1 };
+
+	public:
 
 		// -- Components --
 
@@ -17,8 +23,8 @@ namespace smath {
 		/**
 		 * @returns The number of components that the vector contains.
 		 */
-		static SMATH_CONSTEXPR int size() {
-			return 1;
+		static SMATH_CONSTEXPR length_t size() {
+			return m_size;
 		}
 
 		// -- Constructors --

--- a/smath/types/type_vec2.hpp
+++ b/smath/types/type_vec2.hpp
@@ -8,7 +8,13 @@
 namespace smath {
 
 	template<class T>
-	struct vec<2, T> {
+	class vec<2, T> {
+
+	private:
+
+		static SMATH_CONSTEXPR length_t m_size{ 2 };
+
+	public:
 
 		// -- Components --
 
@@ -18,8 +24,8 @@ namespace smath {
 		/**
 		 * @returns The number of components that the vector contains.
 		 */
-		static SMATH_CONSTEXPR int size() {
-			return 2;
+		static SMATH_CONSTEXPR length_t size() {
+			return m_size;
 		}
 
 		// -- Constructors --

--- a/smath/types/type_vec3.hpp
+++ b/smath/types/type_vec3.hpp
@@ -8,7 +8,13 @@
 namespace smath {
 
 	template<class T>
-	struct vec<3, T> {
+	class vec<3, T> {
+
+	private:
+
+		static SMATH_CONSTEXPR length_t m_size{ 3 };
+
+	public:
 
 		// -- Components --
 
@@ -19,8 +25,8 @@ namespace smath {
 		/**
 		 * @returns The number of components that the vector contains.
 		 */
-		static SMATH_CONSTEXPR int size() {
-			return 3;
+		static SMATH_CONSTEXPR length_t size() {
+			return m_size;
 		}
 
 		// -- Constructors --

--- a/smath/types/type_vec4.hpp
+++ b/smath/types/type_vec4.hpp
@@ -8,7 +8,13 @@
 namespace smath {
 
 	template<class T>
-	struct vec<4, T> {
+	class vec<4, T> {
+
+	private:
+
+		static SMATH_CONSTEXPR length_t m_size{ 4 };
+
+	public:
 
 		// -- Components --
 
@@ -20,8 +26,8 @@ namespace smath {
 		/**
 		 * @returns The number of components that the vector contains.
 		 */
-		static SMATH_CONSTEXPR int size() {
-			return 4;
+		static SMATH_CONSTEXPR length_t size() {
+			return m_size;
 		}
 
 		// -- Constructors --

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -43,7 +43,6 @@ void test_abs() {
 
 	SMATH_STATIC_ASSERT(smath::abs(-9.2f) == std::abs(-9.2f), "Failed abs(-9.2f)");
 	SMATH_STATIC_ASSERT(smath::abs(3.9) == std::abs(3.9), "Failed abs(3.9)");
-	SMATH_STATIC_ASSERT(smath::abs(17) == std::abs(17), "Failed abs(17)");
 
 	std::cout << "Passed\n\n";
 }


### PR DESCRIPTION
# Add
- Support for 4-component vectors to pass into `smath::function`

# Update
- Change all vectors from type `struct` to type `class`


